### PR TITLE
Fixing segmentation fault due to incorrect bounds leading to a stack overflow

### DIFF
--- a/sssp.h
+++ b/sssp.h
@@ -57,7 +57,7 @@ class SSSP {
   SSSP(const Graph &_G, Algorithm _algo, size_t _param = 1 << 21)
       : G(_G), algo(_algo), param(_param) {
     max_queue = 1ULL << static_cast<int>(ceil(log2(G.n)));
-    doubling = ceil(log2(max_queue / MIN_QUEUE)) + 1;
+    doubling = ceil(log2(max_queue / MIN_QUEUE)) + 2;
     info = sequence<Information>(G.n);
     que[0] = que[1] = sequence<NodeId>(max_queue);
     que_num = sequence<NodeId>(max_queue);


### PR DESCRIPTION
I think I found a small bug in the code leading to a stack overflow and in consequence to a segmentation fault on some input graphs.

The definition of the constructor yields the following variable definition:
https://github.com/ucrparlay/Parallel-SSSP/blob/5dc07861c5d655a05e8b94084a9427270e9a7699/sssp.h#L57-L64

This will enable the following code to set `db_len` to a value which is too large:
https://github.com/ucrparlay/Parallel-SSSP/blob/5dc07861c5d655a05e8b94084a9427270e9a7699/sssp.cc#L47-L56

Notice that `db_len` can become larger than `doubling`  since (the +1 I added to `db_len` is since the loop has as condition <=)
```math
    db\_len = 2+log_2\left(\frac{max\_queue}{min\_queue\cdot 2}\right)+1=2+log_2\left(\frac{2^{\lceil{log_2(N)}\rceil}}{2^{k+1}}\right)+1 =  2+log_2\left(2^{\lceil{log_2(N)\rceil}-k-1}\right)+1 = 2+\lceil{log_2(N)\rceil}-k\\
```
```math
doubling = \lceil{log_2\left(\frac{\text{max\_queue}}{\text{min\_queue}}\right)}\rceil+1 = \lceil{log_2\left(\frac{2^{\lceil{log_2(N)}\rceil}}{2^{k}}\right)}\rceil+1 = \lceil{\lceil{log_2(N)\rceil}-k\rceil}+1 = (db\_len-1)
```

The variable `k` is set to `k=14` in the code: https://github.com/ucrparlay/Parallel-SSSP/blob/5dc07861c5d655a05e8b94084a9427270e9a7699/sssp.h#L17

The following code will now allow to read from `qsize[doubling]` which reads from uninitialized memory and can cause a segmentation fault:
https://github.com/ucrparlay/Parallel-SSSP/blob/5dc07861c5d655a05e8b94084a9427270e9a7699/sssp.cc#L77-L82

Since as shown above `db_len` can become larger than `doubling` the previous code snippet allows `t_pt=db_len-1=doubling` which in consequence allows the access to `qsize[doubling]` which is the uninitialized memory.

To confirm the segmentation fault I attached a graph in the adjacency format which will yield a segmentation fault when used as input to the program.  The provided input graph is unweighted.

[segfault_graph.zip](https://github.com/ucrparlay/Parallel-SSSP/files/10132878/segfault_graph.zip)

`./sssp -i segfault_graph.adj -p 2000 -v -a rho-stepping`

The presented bugfix solves the stack overflow and resolves the segmentation fault.